### PR TITLE
Change the acotsp executable location for ACOTSP example

### DIFF
--- a/inst/examples/acotsp/target-runner
+++ b/inst/examples/acotsp/target-runner
@@ -18,8 +18,9 @@ error() {
 }
 
 
-# Path to the ACOTSP software:
-EXE=~/bin/acotsp
+# Path to the ACOTSP executable (this path is relative to the execution directory `execDir` specified in the scenario).
+# EXE="~/bin/acotsp"
+EXE="../ACOTSP-1.03/acotsp"
 
 # Fixed parameters that should be always passed to ACOTSP.
 # The time to be used is always 10 seconds, and we want only one run:

--- a/vignettes/irace-package.Rnw
+++ b/vignettes/irace-package.Rnw
@@ -795,14 +795,6 @@ cd ~/tuning/ACOTSP-1.03
 make
 \end{lstlisting}
 %@
-\item Create a directory for the executable and copy it:
-
-%<<acotsp1,engine='bash',eval=FALSE>>=
-\begin{lstlisting}[style=BashInputStyle]
-mkdir ~/bin/
-cp ~/tuning/ACOTSP-1.03/acotsp ~/bin/
-\end{lstlisting}
-%@
 
 \item Create a directory for executing the experiments and execute \irace:
 


### PR DESCRIPTION
Right now the example asks the user to copy the acotsp example to the `~/bin` as the target-runner looks for the executable there. This is not ideal because not everything is contained in a folder, and it is not as portable. I hope we can change the target-runner and the documentation so that it runs acotsp directly from the example folder. 