### PR TITLE
Refactor optbib to using a git submodule (and bugfix)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,7 +65,6 @@ docs/
 /vignettes/irace-package.pdf
 /vignettes/irace-package.R
 /vignettes/figure
-/vignettes/optbib
 /vignettes/_region_.*
 
 _snaps

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vignettes/optbib"]
+	path = vignettes/optbib
+	url = https://github.com/iridia-ulb/references.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM debian:bullseye
+ARG DEBIAN_FRONTEND=noninteractive
+WORKDIR /usr/app 
+COPY scripts scripts
+RUN scripts/setup.sh
+COPY . .
+RUN make install

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ help:
 
 setup:
 	./scripts/setup.sh
+	@test -f $(PACKAGEDIR)/vignettes/optbib/.git || git submodule update --init
 
 install: build
 	cd $(BINDIR) && R CMD INSTALL $(INSTALL_FLAGS) $(PACKAGE)_$(PACKAGEVERSION).tar.gz
@@ -137,7 +138,7 @@ clean:
 vignettes: vignettes/$(PACKAGE)-package.Rnw vignettes/section/irace-options.tex
 # FIXME: How to display the output of the latex and bibtex commands with R CMD?
 # FIXME: How to halt on warning?
-	@test -d $(PACKAGEDIR)/vignettes/optbib || (echo "ERROR: vignettes/optbib not found. You need to symlink or checkout https://github.com/iridia-ulb/references." && exit 1)
+	@test -f $(PACKAGEDIR)/vignettes/optbib/.git || git submodule update --init
 	cd $(PACKAGEDIR)/vignettes \
 	&& R CMD Sweave --pdf --compact $(PACKAGE)-package.Rnw \
 	&& $(RM) $(PACKAGE)-package.tex

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,15 +1,32 @@
 #!/bin/sh
+setup_apt ()
+{
+    apt-get update
+    apt-get install -y \
+        build-essential \
+        r-base \
+        git \
+        texinfo \
+        texlive \
+        texlive-fonts-extra \
+        texlive-latex-extra \
+        texlive-science \
+        cm-super \
+        r-cran-devtools \
+        libcurl4-gnutls-dev \
+        libxml2-dev \
+        libssl-dev \
+        python3-pip
+    command -V aux2bib || apt-get install -y bibtex2html
+}
+
+command -V apt-get && (setup_apt || echo "Unable to install the apt packages, please check if you are running the script as root.")
+
 R --slave --quiet <<'EOF'
 list_of_packages <- c("devtools", "testthat")
 new_packages <- list_of_packages[!(list_of_packages %in% installed.packages()[,"Package"])]
 if(length(new_packages)) {
  cat("Installing R packages: ", paste0(new_packages, collapse=", "), "\n")
- install_packages(new_packages)
+ install.packages(new_packages, dependencies=TRUE, repos="https://cloud.r-project.org")
 }
 EOF
-# How to make this more general for any Linux/MacOS ?
-# Maybe use bibtool -x instead?
-command -V aux2bib || (echo "aux2bib not found, installing..."; sudo apt install bibtex2html)
-
-test -e ./vignettes/optbib || (echo "vignettes/optbib not found, cloning from github..."; git clone https://github.com/iridia-ulb/references.git vignettes/optbib)
-


### PR DESCRIPTION
Hi! I think it's better to use a git submodule as it is well designed to handle a a git repo inside another git repo.

This PR also fixes three bugs in `setup.sh`:
1. Misspelling of `install.packages`
2. Specifying a mirror for R because otherwise R will ask for input, causing the script to fail.
3. Add `-y` for installing `bibtex2html` to make the script not ask for user input.

Thanks.