### PR TITLE
allow read configuration to read directly from data.frame

### DIFF
--- a/R/readConfiguration.R
+++ b/R/readConfiguration.R
@@ -8,6 +8,7 @@
 #' @template arg_parameters
 #' @template arg_debuglevel
 #' @template arg_text
+#' @param configurationTable (`data.frame`) Data for the configuration as a data.frame. 
 #' 
 #' @return A data frame containing the obtained configurations. 
 #'   Each row of the data frame is a candidate configuration, 
@@ -32,18 +33,20 @@
 #' @author Manuel López-Ibáñez and Jérémie Dubois-Lacoste
 #' @export
 ## FIXME: What about digits?
-readConfigurationsFile <- function(filename, parameters, debugLevel = 0, text)
+readConfigurationsFile <- function(filename, parameters, debugLevel = 0, text, configurationTable)
 {
-  if (missing(filename) && !missing(text)) {
+  if (missing(configurationTable) & missing(filename) && !missing(text)) {
     filename <- strcat("text=", deparse(substitute(text)))
     configurationTable <- read.table(text = text, header = TRUE,
                                      colClasses = "character",
                                      stringsAsFactors = FALSE)
-  } else {
+  } else if (missing(configurationTable) & !missing(filename)) {
     # Read the file.
     configurationTable <- read.table(filename, header = TRUE,
                                      colClasses = "character",
                                      stringsAsFactors = FALSE)
+  } else if (!missing(configurationTable)) {
+    filename <- strcat("configurationTable=", deparse(substitute(configurationTable)))
   }
   irace.assert(is.data.frame(configurationTable))
   nbConfigurations <- nrow(configurationTable)

--- a/man/readConfigurationsFile.Rd
+++ b/man/readConfigurationsFile.Rd
@@ -4,7 +4,13 @@
 \alias{readConfigurationsFile}
 \title{Read parameter configurations from a file}
 \usage{
-readConfigurationsFile(filename, parameters, debugLevel = 0, text)
+readConfigurationsFile(
+  filename,
+  parameters,
+  debugLevel = 0,
+  text,
+  configurationTable
+)
 }
 \arguments{
 \item{filename}{(\code{character(1)}) \cr Filename from which the configurations should be read. The contents should be readable by \code{read.table( , header=TRUE)}.}
@@ -17,6 +23,8 @@ function \code{\link{readParameters}}.}
 
 \item{text}{(\code{character(1)}) \cr If \code{file} is not supplied and this is,
 then parameters are read from the value of \code{text} via a text connection.}
+
+\item{configurationTable}{(\code{data.frame}) Data for the configuration as a data.frame.}
 }
 \value{
 A data frame containing the obtained configurations.


### PR DESCRIPTION
This PR is similar to the previous PR modifying the `readParameters`. This time, we add an option to feed in an r `data.frame` directly. This would be a useful API for things like auto-optimization/iracepy#15. 