### PR TITLE
exit on null for target output

### DIFF
--- a/R/race-wrapper.R
+++ b/R/race-wrapper.R
@@ -527,6 +527,9 @@ execute.experiments <- function(experiments, scenario)
       scenario$targetRunnerParallel(experiments, exec.target.runner,
                                     scenario = scenario,
                                     target.runner = target.runner)
+    if (is.null(target.output)) {
+      irace.error("Stopping because the output of targetRunnerParallel is NULL.")
+    } 
   } else if (scenario$batchmode != 0) {
     target.output <- cluster.lapply (experiments, scenario = scenario)
   } else if (parallel > 1) {


### PR DESCRIPTION
This is mostly needed for auto-optimization/iracepy#22 because error from the user defined function would not propagate from a python function `targetRunnerParallel` to the embedded R instance. If I raise an error, `rpy2` will just swallow the error and return NULL instead. I am not sure if this is a feature or a bug. But in any case, we need to stop irace at that point otherwise it will just go on and fail somewhere else, alerting the user of an "internal bug" and taking down the python interpreter with it due to auto-optimization/iracepy#27. 