### PR TITLE
add ability to use stdout

### DIFF
--- a/R/race-wrapper.R
+++ b/R/race-wrapper.R
@@ -199,7 +199,7 @@ target.evaluator.default <- function(experiment, num.configurations, all.conf.id
 
   debugLevel <- scenario$debugLevel
   targetEvaluator <- scenario$targetEvaluator
-  use_std <- targetEvaluator == 'stdout://'
+  use_std <- is.character(targetEvaluator) && targetEvaluator == 'stdout://'
   if (use_std) targetEvaluator <- 'stdout://targetEvaluator'
   if (!use_std && as.logical(file.access(targetEvaluator, mode = 1))) {
     irace.error ("targetEvaluator", shQuote(targetEvaluator),
@@ -413,7 +413,7 @@ run_target_runner <- function(experiment, scenario)
 
   targetRunner <- scenario$targetRunner
   debugLevel <- scenario$debugLevel
-  use_std <- targetRunner == 'stdout://'
+  use_std <- is.character(targetRunner) && targetRunner == 'stdout://'
   if (use_std) targetRunner <- 'stdout://targetRunner'
   
   if (scenario$aclib) {

--- a/R/race-wrapper.R
+++ b/R/race-wrapper.R
@@ -199,14 +199,16 @@ target.evaluator.default <- function(experiment, num.configurations, all.conf.id
 
   debugLevel <- scenario$debugLevel
   targetEvaluator <- scenario$targetEvaluator
-  if (as.logical(file.access(targetEvaluator, mode = 1))) {
+  use_std <- targetEvaluator == 'stdout://'
+  if (use_std) targetEvaluator <- 'stdout://targetEvaluator'
+  if (!use_std && as.logical(file.access(targetEvaluator, mode = 1))) {
     irace.error ("targetEvaluator", shQuote(targetEvaluator),
                  "cannot be found or is not executable!\n")
   }
 
   cwd <- setwd (scenario$execDir)
   args <- c(configuration.id, instance.id, seed, instance, num.configurations, all.conf.id)
-  output <- runcommand(targetEvaluator, args, configuration.id, debugLevel)
+  output <- runcommand(targetEvaluator, args, configuration.id, debugLevel, use_std = use_std)
   setwd (cwd)
 
   cost <- time <- NULL
@@ -411,6 +413,8 @@ run_target_runner <- function(experiment, scenario)
 
   targetRunner <- scenario$targetRunner
   debugLevel <- scenario$debugLevel
+  use_std <- targetRunner == 'stdout://'
+  if (use_std) targetRunner <- 'stdout://targetRunner'
   
   if (scenario$aclib) {
     # FIXME: Use targetCmdline for this
@@ -433,8 +437,8 @@ run_target_runner <- function(experiment, scenario)
     targetRunner <- targetRunnerLauncher
     error <- "targetRunnerLauncher"
   }
-  file.check(targetRunner, executable = TRUE, text = error)
-  output <- runcommand(targetRunner, args, configuration.id, debugLevel)
+  if (!use_std) {file.check(targetRunner, executable = TRUE, text = error)}
+  output <- runcommand(targetRunner, args, configuration.id, debugLevel, use_std = use_std)
   list(cmd=targetRunner, output=output, args=args)
 }
 

--- a/R/readConfiguration.R
+++ b/R/readConfiguration.R
@@ -685,7 +685,7 @@ checkScenario <- function(scenario = defaultScenario())
                  " must be larger than 1 when mpi is enabled.")
   }
   
-  if (scenario$targetRunner == 'stdout://' && scenario$parallel > 1) {
+  if (is.character(scenario$targetRunner) && scenario$targetRunner == 'stdout://' && scenario$parallel > 1) {
     irace.error (quote.param("parallel"), " cannot be larger than one when stdout:// is set for ",
     quote.param("targetRunner"), ". If you want parallelism, consider using ",
     quote.param("targetEvaluator"), ", which you can use to return the actual outputs after all the calls to targetRunner are printed to stdout.")


### PR DESCRIPTION
I decided to just modify `runcommand` to print to stdout and read from stdin instead of doing anything more complicated. It will just print what it would normally run in the shell to stdout with `stdout://targetRunner` and `stdout://targetEvaluator` as the first argument to differentiate the two. This has the advantage of benefiting from all the documentation and error checking of the codebase. I don't really have a good way to implement parallelism so I just ask the user to use `targetEvaluator` if they want to know all the runs of a batch and run them in parallel. 
 
part of #34