### PR TITLE
Fix column order in checkTargetFiles function

### DIFF
--- a/R/main.R
+++ b/R/main.R
@@ -396,6 +396,10 @@ checkTargetFiles <- function(scenario)
     repair = scenario$repairConfiguration)
   set(configurations, j = ".ID.", value = seq_nrow(configurations))
   
+  # Ensure .ID. is the first column
+  setcolorder(configurations, c(".ID.", setdiff(names(configurations), ".ID.")))
+
+  
   # Read initial configurations provided by the user.
   initConfigurations <- allConfigurationsInit(scenario)
   setDT(initConfigurations)


### PR DESCRIPTION
This commit updates the checkTargetFiles function to reorder the columns of the configurations, ensuring that the .ID. column is the first column. This change addresses an issue with irace.assert failing due to mismatched column orders when comparing configurations with initial configurations provided by the user.