### PR TITLE
Fix psRace() erroring when the post-selection race has nothing left to run

### DIFF
--- a/R/psRace.R
+++ b/R/psRace.R
@@ -177,6 +177,16 @@ psRace <- function(iraceResults, max_experiments, conf_ids = NULL, iteration_eli
       # configurations that have been evaluated on all instances.
       conf_needs_zero <- conf_needs[conf_needs == 0L]
       conf_needs <- truncate_conf_needs(conf_needs[conf_needs > 0L], 16L)
+      if (length(conf_needs) == 0L) {
+        # Every configuration still within budget has already been evaluated on
+        # every instance, so there is no configuration with NA values to add and
+        # nothing to choose between: race the fully evaluated ones. Otherwise the
+        # call below is generate_combs_1(0), which evaluates
+        # seq.int(1L, 2^0 - 1L, 1L) and errors.
+        conf_ids <- names(conf_needs_zero)
+        report_selected(conf_ids, conf_needs_zero)
+        return(conf_ids)
+      }
       combs <- generate_combs_1(length(conf_needs))
       left <- sapply(combs, function(x) max_experiments - sum(conf_needs[x]), USE.NAMES=FALSE)
       irace_assert(any(left >= 0), eval_after=save(iraceResults, file="bug-conf_ids.Rdata"))

--- a/R/race.R
+++ b/R/race.R
@@ -1259,7 +1259,13 @@ elitist_race <- function(race_state, maxExp,
   if (is.null(scenario$targetEvaluator)) {
     # With targetEvaluator, we may have the recorded a new cost value but not
     # counted it as an experiment used if targetRunner was not called.
-    irace_assert(anyDuplicated(local_experiment_log[, c("instance", "configuration")]) == 0L,
+    # A race that executes nothing, as happens in a post-selection race where every
+    # configuration is already evaluated on every instance, leaves
+    # reset_race_experiment_log() equal to rbindlist(NULL): a data.table with no rows
+    # and no columns, which the column selection below cannot be applied to. An empty
+    # log trivially has no duplicates.
+    irace_assert(nrow(local_experiment_log) == 0L ||
+      anyDuplicated(local_experiment_log[, c("instance", "configuration")]) == 0L,
       eval_after = {
         print(local_experiment_log)
         print(mget(ls()))

--- a/tests/testthat/test-psrace-nothing-to-run.R
+++ b/tests/testthat/test-psrace-nothing-to-run.R
@@ -1,0 +1,65 @@
+withr::with_output_sink("test-psrace-nothing-to-run.Rout", {
+
+  # A post-selection race can have nothing left to run: when the budget left is smaller
+  # than the number of experiments that any not-yet-fully-evaluated configuration would
+  # need, the only configurations that fit are the ones already evaluated on every
+  # instance. psRace() used to error with "wrong sign in 'by' argument" and, once that
+  # was fixed, the race that then executes no experiments used to error with
+  # "columns not found: [instance, configuration]".
+  test_that("psRace with nothing left to run", {
+    skip_on_cran()
+    parameters <- readParameters(text = '
+a "" i (1, 10)
+b "" i (1, 10)
+')
+    logFile <- withr::local_tempfile(fileext = ".Rdata")
+    scenario <- defaultScenario(list(
+      parameters = parameters,
+      instances = 1:5,
+      deterministic = TRUE,
+      elitist = TRUE,
+      # The post-selection race is run by hand below, with a budget that leaves it
+      # nothing to do.
+      postselection = FALSE,
+      maxExperiments = 200,
+      parallel = 1,
+      seed = 1234,
+      logFile = logFile,
+      targetRunner = function(experiment, scenario)
+        list(cost = experiment$configuration$a * as.integer(experiment$instance) +
+               experiment$configuration$b)
+    ))
+    irace(scenario)
+
+    irace_log <- read_logfile(logFile)
+    elites <- irace_log$allElites[[length(irace_log$allElites)]]
+    conf_ids <- unique(c(elites, irace_log$allConfigurations[[".ID."]]))
+    conf_ids <- conf_ids[!is.na(conf_ids)]
+    conf_needs <- colSums(
+      is.na(irace_log$experiments[, as.character(conf_ids), drop = FALSE]))
+
+    # The two conditions that take psRace() down the path under test, asserted so that
+    # this fails loudly if it ever stops reaching it: every instance has been seen, and
+    # with this budget every configuration that fits has nothing left to run.
+    max_experiments <- 2L
+    expect_equal(nrow(irace_log$experiments) - min(conf_needs),
+                 length(irace_log$scenario$instances))
+    conf_needs <- conf_needs[conf_needs <= max_experiments]
+    expect_gt(length(conf_needs), 1L)
+    expect_true(all(conf_needs == 0L))
+
+    psrace_logFile <- withr::local_tempfile(fileext = ".Rdata")
+    expect_no_error(
+      psRace(irace_log, max_experiments = max_experiments,
+             psrace_logFile = psrace_logFile))
+
+    psrace_log <- read_logfile(psrace_logFile)
+    expect_false(is.null(psrace_log$psrace_log))
+    # Nothing new could be measured, so post-selection can only return configurations it
+    # was given, and must return at least one.
+    psrace_elites <- psrace_log$allElites[[length(psrace_log$allElites)]]
+    expect_gt(length(psrace_elites), 0L)
+    expect_true(all(psrace_elites %in% conf_ids))
+  })
+
+}) # withr::with_output_sink()


### PR DESCRIPTION
Fixes #97 

When the budget left for the post-selection race is smaller than the number of experiments
any not-yet-fully-evaluated configuration would need, the only configurations that fit are
the ones already evaluated on every instance. Two places do not expect that. Because
post-selection runs after the race and testing runs after post-selection, the run dies at
the very end and the logfile never gets its `testing` block.

## Changes

**`R/psRace.R`** — `get_confs_for_psrace()` splits the in-budget candidates into need-0 and
need->0 and enumerates subsets of the second group. The comment above it states the
assumption that the second group is non-empty; when it is empty, `generate_combs_1(0)`
evaluates `seq.int(1L, 2^0 - 1L, 1L)` and errors with `wrong sign in 'by' argument`. With
nothing to choose between, the selection is just the fully evaluated configurations, so the
patch returns them and skips the enumeration.

**`R/race.R`** — with the above fixed, the post-selection race then executes zero
experiments, and `reset_race_experiment_log()` is `rbindlist(NULL)`: a `data.table` with no
rows *and no columns*. The assertion below it selects `c("instance", "configuration")` from
it and errors with `columns not found`. An empty log trivially has no duplicates, so the
patch checks it only when it has rows. (`irace_assert()` has no debug gate, so this fires in
any run.)

**`tests/testthat/test-psrace-nothing-to-run.R`** — regression test. It runs a small deterministic,
elitist scenario to completion with `postselection = FALSE`, then calls `psRace()` with
`max_experiments = 2L`. It asserts the two conditions that take the code down this path
before exercising it — that every instance has been seen
(`n_done == length(scenario$instances)`, which is what stops the earlier branch from
absorbing the case) and that every configuration within budget has nothing left to run — so
it fails loudly if it ever stops reaching the bug rather than passing silently.